### PR TITLE
Updated nix derivation to use unstable glfw

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,15 @@
 with import <nixpkgs> {};
 
+let
+  unstable = import
+    (fetchTarball
+      https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz) {};
+in
 stdenv.mkDerivation {
   name = "chemilang";
   src = ./.;
 
-  buildInputs = [ cmake clang gtest glew glfw freetype glm ];
+  buildInputs = [ cmake clang gtest glew unstable.glfw freetype glm ];
 
   buildPhase = "cmake . && make";
 


### PR DESCRIPTION
This should make it build on NixOS again.